### PR TITLE
Version 3

### DIFF
--- a/rhost.js
+++ b/rhost.js
@@ -109,6 +109,17 @@ export function encodeString(str) {
 	return ret
 }
 
+/* Translate Rhost-encoded Unicode into utf-8 */
+export function decodeString(str) {
+	return str.replace(/%<u([0-9a-fA-F]+)>/g, function(match, p1) {
+		try {
+			return String.fromCodePoint(Number.parseInt(p1, 0x10))
+		} catch(e) {
+			return p1
+		}
+	})
+}
+
 export function print(str) {
 	if(typeof str != "string") {
 		str = Deno.inspect(str)


### PR DESCRIPTION
This should get tagged v3.

I've added Rhost.decodeString because somehow I didn't consider what would happen if you wanted to parse perfectly cromulent inputs like ü, ß, or 漢字.

I was honestly focused on the outputs, for things like +sheet systems.

But this adds a very much needed function, which I'm then going to use in the gradient.js example in Rhost trunk.